### PR TITLE
Fix hooks being overwritten by patches

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -141,7 +141,8 @@ impl ArxanPatch {
             let mut i_reloc = relocs.into_iter().peekable();
             for (rva, bytes) in &mut writes {
                 while let Some(reloc) = i_reloc.next_if(|r| r + 8 <= *rva + bytes.len() as u32) {
-                    let Some(offset) = reloc.checked_sub(*rva).map(|r| r as usize) else {
+                    let Some(offset) = reloc.checked_sub(*rva).map(|r| r as usize)
+                    else {
                         continue;
                     };
                     let target_bytes = &mut bytes[offset..offset + 8];


### PR DESCRIPTION
Hotfix for hooks that are overlapping with other patch regions being ordered before said patches, undoing them in the patching process.