### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.0] - 2025-09-19
+
+### Breaking Changes
+- Added `kind` field to `dearxan::analysis::encryption::EncryptedRegionList`
+- Methods of `dearxan::analysis::encryption::EncryptedRegion`
+- `Sync` bound now present on `image` parameter of `dearxan::patch::ArxanPatch::build_from_stubs` if the `rayon` feature is enabled
+
+### Added
+- Region extraction analyses for Arxan's rotate-mulitply-xor and constant subtraction pseudo-encryption algorithms
+
+### Changed
+- Greatly improved robustness of encrypted region conflict resolution and elimination
+
+### Fixed
+- Sound partially broken in DS3 due to missing Arxan encrypted region for sound binder encryption keys
+
+### Stabilized
+- `dearxan::analysis::encryption` APIs, deprecating its usage through the `internal_api` feature
+
 ## [v0.4.1] - 2025-09-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "50eb3a329e19d78c3a3dfa4ec5a51ecb84fa3a20c06edad04be25356018218f9"
 
 [[package]]
 name = "dearxan"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "atomic-wait",
  "bitfield-struct",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "dearxan-test-utils"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "log",
  "pelite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["test_dll", "test_launcher", "test_utils"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 authors = ["William Tremblay"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -67,7 +67,7 @@ features = [
 simplelog.workspace = true
 clap.workspace = true
 clap-num = "1.2"
-dearxan-test-utils = { version = "0.4.1", path = "test_utils" }
+dearxan-test-utils = { version = "0.5.0", path = "test_utils" }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
 pretty-hex = "0.4.1"
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For Souls games compatible with [me3](https://github.com/garyttierney/me3), this
 
 Add the following to your `Cargo.toml`:
 ```toml
-dearxan = "0.4.0"
+dearxan = "0.5.0"
 ```
 
 Then, simply call the `dearxan::disabler::neuter_arxan` function once, ideally before the entry point of the game is executed: 

--- a/src/analysis/encryption.rs
+++ b/src/analysis/encryption.rs
@@ -181,10 +181,6 @@ pub fn try_read_varint(mut reader: impl io::Read) -> io::Result<u32> {
     }
 }
 
-/// Subtract decryptor.
-///
-/// Another data obfuscation "cipher" used by Arxan.
-
 /// A contiguous region of bytes encrypted by Arxan.
 ///
 /// See the module-level documentation for more information.
@@ -428,7 +424,7 @@ pub fn apply_relocs_and_resolve_conflicts<
         let base_bytes_iter = p.rlist.regions.iter().flat_map(|r| {
             image
                 .read(base_va + r.rva as u64, r.size)
-                .map_or(&[] as &[u8], |s| &s[..r.size as usize])
+                .map_or(&[] as &[u8], |s| &s[..r.size])
         });
         p.base_entropy = shannon_entropy(base_bytes_iter.copied());
         p.entropy = shannon_entropy(p.rlist.decrypted_stream.iter().copied());
@@ -475,5 +471,8 @@ pub fn apply_relocs_and_resolve_conflicts<
         }
     };
 
-    Ok(processed.into_iter().filter_map(|p| (!p.eliminated).then(|| p.rlist)).collect())
+    Ok(processed
+        .into_iter()
+        .filter_map(|p| (!p.eliminated).then_some(p.rlist))
+        .collect())
 }

--- a/src/analysis/encryption.rs
+++ b/src/analysis/encryption.rs
@@ -9,17 +9,18 @@
 //! The result of this process is the creation of two function-like Arxan stubs: one is called
 //! before the code/data needs to be accessed, and the other after to replace it with garbage bytes.
 //!
-//! To achieve this, the stubs first use the
-//! [Tiny Encryption Algorithm](https://en.wikipedia.org/wiki/Tiny_Encryption_Algorithm) (TEA)
-//! with a per-stub hardcoded key to decrypt a variable-length list of (offset, size) pairs, each
+//! There are two types of Arxan encryption: TEA and RMX (rotate-multiply-xor).
+//!
+//! Stubs of both types first recover a list of (offset, size) pairs, each
 //! representing a contiguous region to be decrypted. These pairs are encoded as 7-bit
 //! variable-length integers (varints) where the high bit is used as a terminator, and the initial
 //! offset is the base of the executable image. A running offset of [`u32::MAX`] indicates the end
-//! of the list.
+//! of the list. TEA stubs encrypt this offset list using TEA with a per-stub hardcoded key.
 //!
-//! The ciphertext for these regions is stored as a single contiguous blob, encrypted using a
-//! different per-stub hardcoded key. After a region is parsed from the varint list, the
-//! corresponding ciphertext bytes will be decrypted and copied to it.
+//!
+//! The ciphertext for these regions is stored as a single contiguous blob, encrypted with either
+//! TEA or RMX (in both cases using a hardcoded key). After a region is parsed from the varint list,
+//! the corresponding ciphertext bytes will be decrypted and copied to it.
 //!
 //! The "encryption" process is exactly the same, except that the ciphertext used decrypts to random
 //! garbage bytes. These bytes seem to be uniformly distributed and can thus be effectively
@@ -29,101 +30,160 @@
 //! The static data structures described above are modeled through the [`EncryptedRegion`] and
 //! [`EncryptedRegionList`] types.
 
-use std::io::{self, Read};
+use std::{
+    io::{self, Read},
+    marker::PhantomData,
+};
 
-/// Compute the Shannon entropy of a slice of bytes.
+use crate::analysis::{ImageView, vm::image::BadRelocsError};
+
+/// Abstraction over a decryption algorithm operating in fixed-size blocks.
+pub trait Decryptor {
+    /// The cipher's block type (e.g. `[u32; 2]` for TEA).
+    type Block: bytemuck::Pod;
+
+    /// Decrypt a single block in place, updating the decryptor's state.
+    fn decrypt(&mut self, block: &mut Self::Block);
+}
+
+/// [`Decryptor`] wrapper which decrypts an arbitrary [`io::Read`] stream.
+pub struct DecryptReader<R: Read, D: Decryptor> {
+    reader: R,
+    decryptor: D,
+    block_buffer: D::Block,
+    consumed: usize,
+}
+
+impl<R: Read, D: Decryptor> DecryptReader<R, D> {
+    const BLOCK_SIZE: usize = size_of::<D::Block>();
+
+    /// Create a [`DecryptReader`] from an [`io::Read`] implementationa and a decryptor.
+    pub fn new(reader: R, decryptor: D) -> Self {
+        Self {
+            reader,
+            decryptor,
+            block_buffer: bytemuck::Zeroable::zeroed(),
+            consumed: size_of::<D::Block>(),
+        }
+    }
+}
+
+impl<R: Read, D: Decryptor> Read for DecryptReader<R, D> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.consumed == Self::BLOCK_SIZE {
+            self.reader.read_exact(bytemuck::bytes_of_mut(&mut self.block_buffer))?;
+            self.decryptor.decrypt(&mut self.block_buffer);
+            self.consumed = 0;
+        }
+
+        let to_read = (Self::BLOCK_SIZE - self.consumed).min(buf.len());
+        buf[..to_read].copy_from_slice(
+            &bytemuck::bytes_of(&self.block_buffer)[self.consumed..self.consumed + to_read],
+        );
+        self.consumed += to_read;
+        Ok(to_read)
+    }
+}
+
+/// wrapper around a block decrypt function that implements [`Decryptor`].
+pub struct FnDecryptor<B: bytemuck::Pod, F: FnMut(&mut B)>(F, PhantomData<fn(&mut B)>);
+
+impl<B: bytemuck::Pod, F: FnMut(&mut B)> FnDecryptor<B, F> {
+    pub fn new(fun: F) -> Self {
+        Self(fun, PhantomData)
+    }
+}
+
+impl<B: bytemuck::Pod, F: FnMut(&mut B)> Decryptor for FnDecryptor<B, F> {
+    type Block = B;
+
+    fn decrypt(&mut self, block: &mut Self::Block) {
+        self.0(block)
+    }
+}
+
+/// Encryption algorithms used by Arxan to obfuscate static data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArxanDecryptionKind {
+    /// Standard 32-round TEA.
+    Tea,
+    /// Custom rotate-multiply-xor algorithm.
+    Rmx,
+    /// Simple subtraction from a constant.
+    Sub,
+}
+
+/// 32-round TEA (Tiny Encryption Algorithm) decryptor.
+pub fn tea_decryptor(key: &[u8; 16]) -> impl Decryptor<Block = [u32; 2]> {
+    let key: [u32; 4] = bytemuck::pod_read_unaligned(key);
+    FnDecryptor::new(move |block: &mut [u32; 2]| {
+        const NUM_ROUNDS: u32 = 32;
+        const DELTA: u32 = 0x9E3779B9;
+        let mut sum = 0xC6EF3720;
+
+        fn fiestel_round(b1: u32, b2: &mut u32, k1: u32, k2: u32, sum: u32) {
+            let k1_term = (b1 << 4).wrapping_add(k1) ^ b1.wrapping_add(sum);
+            let k2_term = (b1 >> 5).wrapping_add(k2);
+            *b2 = b2.wrapping_sub(k1_term ^ k2_term);
+        }
+
+        for _ in 0..NUM_ROUNDS {
+            fiestel_round(block[0], &mut block[1], key[2], key[3], sum);
+            fiestel_round(block[1], &mut block[0], key[0], key[1], sum);
+            sum = sum.wrapping_sub(DELTA);
+        }
+    })
+}
+
+/// Rotate-multiply-xor decryptor.
 ///
-/// This is useful to discriminate between non-random and random data, provided its length is
-/// sufficient.
-pub fn shannon_entropy(bytes: &[u8]) -> f64 {
-    if bytes.is_empty() {
-        return 0.0;
-    }
+/// This algorithm seems to have been invented by the Arxan developers. It is reminiscent of ARX
+/// ciphers, but uses multiplication. Its cryptographic security seems poor.
+pub fn rmx_decryptor(mut key: u32) -> impl Decryptor<Block = u32> {
+    let mut key_rot = key & 0x1f;
 
-    let mut byte_dist = [0usize; 256];
-    bytes.iter().for_each(|&b| byte_dist[b as usize] += 1);
-
-    let len_log2 = (bytes.len() as f64).log2();
-    // -sum b/N * log2(b/N) = 1/N sum b(log2 N - log2 b)
-    let plogp_sum: f64 = byte_dist
-        .into_iter()
-        .filter(|&b| b != 0)
-        .map(|b| (b as f64) * (len_log2 - (b as f64).log2()))
-        .sum();
-
-    plogp_sum / (bytes.len() as f64)
+    FnDecryptor::new(move |block: &mut u32| {
+        key = key.rotate_left(key_rot);
+        *block = block.wrapping_sub(key.wrapping_mul(key_rot));
+        key_rot ^= !*block;
+    })
 }
 
-/// Decrypt a single block of 8 bytes that was encrypted using 32-round TEA.
-pub fn tea_block_decrypt(block: &mut [u32; 2], key: &[u32; 4]) {
-    const NUM_ROUNDS: u32 = 32;
-    const DELTA: u32 = 0x9E3779B9;
-    let mut sum = 0xC6EF3720;
-
-    fn fiestel_round(b1: u32, b2: &mut u32, k1: u32, k2: u32, sum: u32) {
-        let k1_term = (b1 << 4).wrapping_add(k1) ^ b1.wrapping_add(sum);
-        let k2_term = (b1 >> 5).wrapping_add(k2);
-        *b2 = b2.wrapping_sub(k1_term ^ k2_term);
-    }
-
-    for _ in 0..NUM_ROUNDS {
-        fiestel_round(block[0], &mut block[1], key[2], key[3], sum);
-        fiestel_round(block[1], &mut block[0], key[0], key[1], sum);
-        sum = sum.wrapping_sub(DELTA);
-    }
-}
-
-/// Decrypt a slice that was encrypted using 32-round TEA.
+/// Subtraction decryptor.
 ///
-/// The length of the slice does not need to be a multiple of 8 (the TEA block size). However, if an
-/// incomplete block is present, it will not be decrypted.
-pub fn tea_decrypt(bytes: &mut [u8], key: &[u8; 16]) {
-    #[cfg(feature = "rayon")]
-    use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
-
-    let local_key: [u32; 4] = bytemuck::cast(*key);
-
-    #[cfg(feature = "rayon")]
-    let iter = bytes.par_chunks_exact_mut(8);
-    #[cfg(not(feature = "rayon"))]
-    let iter = bytes.chunks_exact_mut(8);
-
-    iter.for_each(|chunk| {
-        let mut local_block: [u32; 2] = bytemuck::pod_read_unaligned(chunk);
-        tea_block_decrypt(&mut local_block, &local_key);
-        chunk.copy_from_slice(bytemuck::bytes_of(&local_block));
-    });
-}
-
-/// Error type which may be raised when reading a 32-bit varint-encoded integer.
-pub enum VarintError {
-    /// The varint does not fit within an unsigned 32-bit integer.
-    Overflow,
-    /// No stop bit was read before the end of the byte slice.
-    NoStopBit,
+/// This is more obfuscation than encryption. Blocks of 4 bytes are subtracted from a constant
+/// "key".
+pub fn sub_decryptor(key: u32) -> impl Decryptor<Block = u32> {
+    FnDecryptor::new(move |block| *block = key.wrapping_sub(*block))
 }
 
 /// Try to parse a 32-bit unsigned integer encoded as a varint.
 ///
-/// On success, returns both the decoded number and the amount of bytes read.
-pub fn try_read_varint(bytes: &[u8]) -> Result<(u32, usize), VarintError> {
+/// On success, returns the decoded number.
+pub fn try_read_varint(mut reader: impl io::Read) -> io::Result<u32> {
     let mut result = 0u32;
     let mut num_read = 0u32;
 
-    for &b in bytes {
+    let mut b = 0u8;
+    loop {
+        reader.read_exact(std::slice::from_mut(&mut b))?;
+
         result = (b as u32 & 0x7F)
             .checked_shl(7 * num_read)
             .and_then(|s| result.checked_add(s))
-            .ok_or(VarintError::Overflow)?;
+            .ok_or(io::ErrorKind::InvalidData)?;
 
         num_read += 1;
 
         if b < 0x80 {
-            return Ok((result, num_read as usize));
+            return Ok(result);
         }
     }
-    Err(VarintError::NoStopBit)
 }
+
+/// Subtract decryptor.
+///
+/// Another data obfuscation "cipher" used by Arxan.
 
 /// A contiguous region of bytes encrypted by Arxan.
 ///
@@ -147,56 +207,49 @@ impl EncryptedRegion {
         list.decrypted_stream.get(self.stream_offset..self.stream_offset + self.size)
     }
 
-    /// Try to extract a list of encrypted regions from the encrypted varint-encoded offset size
+    /// Try to extract a list of encrypted regions from a stream of varint-encoded offset size
     /// pairs.
     ///
     /// See the module-level documentation for more information.
-    pub fn try_decrypt_list(encrypted_varints: &[u8], key: &[u8; 16]) -> Option<Vec<Self>> {
+    pub fn try_from_varints(mut reader: impl Read) -> io::Result<Vec<Self>> {
         let mut regions = Vec::new();
 
-        let mut decoded_varints = Vec::new();
-        let mut cursor = 0;
         let mut rva = 0u32;
         let mut stream_offset = 0usize;
 
-        let key_local = bytemuck::cast(*key);
-        'outer: for block in encrypted_varints.chunks_exact(8) {
-            let mut block: [u32; 2] = bytemuck::pod_read_unaligned(block);
-            tea_block_decrypt(&mut block, &key_local);
-            decoded_varints.extend_from_slice(bytemuck::bytes_of(&block));
-
-            loop {
-                let (offset, offset_size) = match try_read_varint(&decoded_varints[cursor..]) {
-                    Ok((o, s)) => (o, s),
-                    Err(VarintError::Overflow) => break 'outer,
-                    Err(VarintError::NoStopBit) => break,
-                };
-                if rva.checked_add(offset) == Some(u32::MAX) {
-                    return Some(regions);
-                }
-
-                let (size, size_size) =
-                    match try_read_varint(&decoded_varints[cursor + offset_size..]) {
-                        Ok((o, s)) => (o, s),
-                        Err(VarintError::Overflow) => break 'outer,
-                        Err(VarintError::NoStopBit) => break,
-                    };
-                cursor += offset_size + size_size;
-
-                rva = rva.checked_add(offset)?;
-
-                regions.push(Self {
-                    stream_offset,
-                    size: size as usize,
-                    rva,
-                });
-
-                rva = rva.checked_add(size)?;
-                stream_offset += size as usize;
+        // as an optimization to cut down the time before an error
+        // for false positives, disallow zero offsets/sizes
+        loop {
+            let offset = try_read_varint(&mut reader)?;
+            if offset == 0 {
+                return Err(io::ErrorKind::InvalidData.into());
             }
-        }
 
-        None
+            rva = rva.checked_add(offset).ok_or(io::ErrorKind::InvalidData)?;
+            if rva == u32::MAX {
+                return Ok(regions);
+            }
+
+            let size = try_read_varint(&mut reader)?;
+            if size == 0 {
+                return Err(io::ErrorKind::InvalidData.into());
+            }
+
+            regions.push(Self {
+                stream_offset,
+                size: size as usize,
+                rva,
+            });
+            rva = rva.checked_add(size).ok_or(io::ErrorKind::InvalidData)?;
+            stream_offset += size as usize;
+        }
+    }
+
+    pub fn intersects(&self, other: &EncryptedRegion) -> bool {
+        let end = self.rva as usize + self.size;
+        let other_end = other.rva as usize + other.size;
+
+        end.min(other_end) > self.rva.max(other.rva) as usize
     }
 }
 
@@ -206,6 +259,7 @@ impl EncryptedRegion {
 /// See the module-level documentation for more details.
 #[derive(Debug, Clone)]
 pub struct EncryptedRegionList {
+    pub kind: ArxanDecryptionKind,
     pub regions: Vec<EncryptedRegion>,
     pub decrypted_stream: Vec<u8>,
 }
@@ -226,20 +280,44 @@ impl EncryptedRegionList {
     }
 
     pub fn try_new(
+        kind: ArxanDecryptionKind,
         regions: Vec<EncryptedRegion>,
-        mut ciphertext: impl Read,
-        key: &[u8; 16],
+        mut decrypted_stream: impl Read,
     ) -> io::Result<Self> {
         let ctext_len = regions.last().map(|r| r.stream_offset + r.size).unwrap_or(0);
 
-        let mut decrypted_stream = vec![0; ctext_len.next_multiple_of(8)];
-        ciphertext.read_exact(&mut decrypted_stream)?;
-        tea_decrypt(&mut decrypted_stream, key);
-        decrypted_stream.truncate(ctext_len);
+        let mut plaintext = vec![0; ctext_len];
+        decrypted_stream.read_exact(&mut plaintext)?;
 
         Ok(Self {
+            kind,
             regions,
-            decrypted_stream,
+            decrypted_stream: plaintext,
         })
     }
+}
+
+/// Compute the Shannon entropy of a sequence of bytes.
+///
+/// This is useful to discriminate between non-random and random data, provided its length is
+/// sufficient.
+pub fn shannon_entropy(bytes: impl IntoIterator<Item = u8>) -> f64 {
+    let mut byte_dist = [0usize; 256];
+    let mut len = 0;
+    for b in bytes {
+        byte_dist[b as usize] += 1;
+        len += 1;
+    }
+
+    let len_log2 = (len as f64).log2();
+    // -sum b/N * log2(b/N) = 1/N sum b(log2 N - log2 b)
+    let plogp_sum: f64 = byte_dist
+        .into_iter()
+        .filter(|&b| b != 0)
+        // rust-analyzer reports an error without the type hint (but not rustc)
+        .map(|b: usize| (b as f64) * (len_log2 - (b as f64).log2()))
+        .sum();
+
+    plogp_sum / (len as f64)
+}
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -21,8 +21,8 @@ pub mod internal {
         pub use super::super::cfg::*;
     }
     #[deprecated(
-        since = "0.4.2",
-        reason = "dearxan::analysis::encryption has been stabilized"
+        since = "0.5.0",
+        note = "dearxan::analysis::encryption has been stabilized"
     )]
     pub mod encryption {
         #[doc(inline)]

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,5 +1,5 @@
 mod cfg;
-mod encryption;
+pub mod encryption;
 pub mod entry_point;
 mod stub_info;
 mod vm;
@@ -20,6 +20,10 @@ pub mod internal {
         #[doc(inline)]
         pub use super::super::cfg::*;
     }
+    #[deprecated(
+        since = "0.4.2",
+        reason = "dearxan::analysis::encryption has been stabilized"
+    )]
     pub mod encryption {
         #[doc(inline)]
         pub use super::super::encryption::*;
@@ -35,9 +39,9 @@ pub mod internal {
 }
 
 pub use self::{
-    encryption::{EncryptedRegion, EncryptedRegionList, shannon_entropy},
+    encryption::{EncryptedRegion, EncryptedRegionList},
     stub_info::{ReturnGadget, StubAnalysisError, StubAnalyzer, StubInfo},
-    vm::{ImageView, image::WithBase},
+    vm::image::{BadRelocsError, ImageView, WithBase},
 };
 
 fn find_test_rsp_instructions<I: ImageView>(image: &I) -> Vec<u64> {
@@ -94,7 +98,7 @@ pub fn analyze_all_stubs_with<
     .collect()
 }
 
-/// Analyze all Arxan stubs found in the executable image using a default [`StubAnalyzer`]
+/// Analyze all Arxan stubs found in the executable image using a default [`StubAnalyzer`].
 ///
 /// If you need to configure the analyzer, consider using [`analyze_all_stubs_with`] instead.
 pub fn analyze_all_stubs<

--- a/src/analysis/stub_info.rs
+++ b/src/analysis/stub_info.rs
@@ -128,8 +128,6 @@ impl<'a> RmxEncryptionState<'a> {
             && let Some(va) = step.state.virtual_address(step.instruction, 1)
             && let Some(varints) = image.read(va, 2)
         {
-            // enforce max length of 256 to avoid false positives
-            // let varints = varints.get(..0x100).unwrap_or(varints);
             if let Ok(rlist) = EncryptedRegion::try_from_varints(varints) {
                 log::trace!("found rmx region list info: {:x?}", rlist);
                 *regions = Some(rlist);

--- a/src/analysis/stub_info.rs
+++ b/src/analysis/stub_info.rs
@@ -127,11 +127,10 @@ impl<'a> RmxEncryptionState<'a> {
             && step.instruction.op1_kind() == OpKind::Memory
             && let Some(va) = step.state.virtual_address(step.instruction, 1)
             && let Some(varints) = image.read(va, 2)
+            && let Ok(rlist) = EncryptedRegion::try_from_varints(varints)
         {
-            if let Ok(rlist) = EncryptedRegion::try_from_varints(varints) {
-                log::trace!("found rmx region list info: {:x?}", rlist);
-                *regions = Some(rlist);
-            }
+            log::trace!("found rmx region list info: {:x?}", rlist);
+            *regions = Some(rlist);
         }
         if ciphertext.is_none()
             && step.instruction.code() == Code::Imul_r32_rm32

--- a/src/analysis/vm/mod.rs
+++ b/src/analysis/vm/mod.rs
@@ -223,7 +223,7 @@ impl<I: ImageView, D: Clone> ProgramState<I, D> {
             let mut decoder = Decoder::with_ip(64, instr_bytes, ip, DecoderOptions::NONE);
             decoder.decode_out(&mut instruction);
             if instruction.is_invalid() {
-                log::debug!("invalid instruction at {ip:x}");
+                log::trace!("invalid instruction at {ip:x}");
                 execution_path.truncate(*fork_index);
                 fork_stack.pop();
                 continue;


### PR DESCRIPTION
### Breaking Changes
- Added `kind` field to `dearxan::analysis::encryption::EncryptedRegionList`
- Methods of `dearxan::analysis::encryption::EncryptedRegion`
- `Sync` bound now present on `image` parameter of `dearxan::patch::ArxanPatch::build_from_stubs` if the `rayon` feature is enabled

### Added
- Region extraction analyses for Arxan's rotate-mulitply-xor and constant subtraction pseudo-encryption algorithms

### Changed
- Greatly improved robustness of encrypted region conflict resolution and elimination

### Fixed
- Sound partially broken in DS3 due to missing Arxan encrypted region for sound binder encryption keys

### Stabilized
- `dearxan::analysis::encryption` APIs, deprecating its usage through the `internal_api` feature

Fixes #23 