### PR TITLE
fix: run disabler until no stubs detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [dev]
   pull_request:
-    branches-ignore: [main]
 
 jobs:
   clippy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.4] - 2026-08-15
+
+## Fixed
+
+- dearxan not detecting or patching encrypted Arxan stubs. These show up in Elden Ring and Nightreign. This is fixed by running repeated analysis and decryption passes until
+no new stubs show up.
+
 ## [v0.5.3] - 2026-01-11
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "50eb3a329e19d78c3a3dfa4ec5a51ecb84fa3a20c06edad04be25356018218f9"
 
 [[package]]
 name = "dearxan"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "atomic-wait",
  "bitfield-struct",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "dearxan-test-utils"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "log",
  "pelite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["test_dll", "test_launcher", "test_utils"]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 authors = ["William Tremblay"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Download the static library from the [Releases](https://github.com/tremwil/dearx
 
 ## Writing your own patcher
 
-If you want to patch an executable on disk, for example, you will need to write your own disabler. This will involve analyzing the Arxan stubs in the binary with `dearxan::analysis::analyze_all_stubs` or equivalent APIs, then passing the resulting `StubInfo` values to `dearxan::patch::ArxanPatch::build_from_stubs`. From there you will have to iterate over the patches and apply them to the executable manually.
+If you want to patch an executable on disk, for example, you will need to write your own disabler. This will involve analyzing the Arxan stubs in the binary with `dearxan::analysis::analyze_all_stubs` or equivalent APIs, then passing the resulting `StubInfo` values to `dearxan::patch::ArxanPatch::build_from_stubs`. From there you will have to iterate over the patches and apply them to the executable manually. This process must be repeated until no new stubs are found, since some games have encrypted stubs that are not discovered during the first analysis pass.
 
 Note that currently, for this to work on a live executable image it is important to make sure that the Arxan entry point stub has been invoked. For FromSoftware games, beware that binaries may be wrapped in SteamStub as well. 
 

--- a/src/disabler/code_buffer.rs
+++ b/src/disabler/code_buffer.rs
@@ -85,7 +85,7 @@ impl CodeBuffer {
 
     pub fn reserve(&self, size: usize) -> Option<*mut [u8]> {
         self.cursor
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
                 let new_cursor = c.with_addr(c.addr().checked_add(size)?);
                 (c < self.end).then_some(new_cursor)
             })

--- a/src/disabler/mod.rs
+++ b/src/disabler/mod.rs
@@ -116,50 +116,66 @@ where
             make_module_rwe(game.pe);
         }
 
-        let analysis_time = Instant::now();
-        log::info!("analyzing Arxan stubs");
+        let all_passes_time = Instant::now();
+        let mut pass = 0;
 
-        let analysis_results = crate::analysis::analyze_all_stubs(game.pe);
-        let num_found = analysis_results.len();
-        log::info!(
-            "analysis completed in {:.3?}. {} stubs found",
-            analysis_time.elapsed(),
-            num_found
-        );
+        loop {
+            pass += 1;
+            log::info!("---- pass {pass} ----");
 
-        let good_stubs: Vec<_> = analysis_results
-            .into_iter()
-            .filter_map(|maybe_stub| maybe_stub.inspect_err(|err| log::error!("{err}")).ok())
-            .collect();
+            let analysis_time = Instant::now();
+            log::info!("analyzing remaining Arxan stubs");
 
-        if good_stubs.len() != num_found {
-            return Err("failed to generate patches for all stubs".into());
-        }
-
-        log::info!("generating patches");
-        let patch_gen_time = Instant::now();
-        let patches = crate::patch::ArxanPatch::build_from_stubs(
-            game.pe,
-            Some(game.preferred_base),
-            good_stubs.iter(),
-        )?;
-
-        log::info!(
-            "generated {} patches in {:.3?}",
-            patches.len(),
-            patch_gen_time.elapsed()
-        );
-
-        log::info!("applying patches");
-        let patch_apply_time = Instant::now();
-        for patch in &patches {
-            unsafe {
-                apply_patch(patch, &game.hook_buffer);
+            let analysis_results = crate::analysis::analyze_all_stubs(game.pe);
+            if analysis_results.is_empty() {
+                break;
             }
+
+            let num_found = analysis_results.len();
+            log::info!(
+                "analysis pass completed in {:.3?}. {} stubs found",
+                analysis_time.elapsed(),
+                num_found
+            );
+
+            let good_stubs: Vec<_> = analysis_results
+                .into_iter()
+                .filter_map(|maybe_stub| maybe_stub.inspect_err(|err| log::error!("{err}")).ok())
+                .collect();
+
+            if good_stubs.len() != num_found {
+                return Err("failed to generate patches for all stubs".into());
+            }
+
+            log::info!("generating patches");
+            let patch_gen_time = Instant::now();
+            let patches = crate::patch::ArxanPatch::build_from_stubs(
+                game.pe,
+                Some(game.preferred_base),
+                good_stubs.iter(),
+            )?;
+
+            log::info!(
+                "generated {} patches in {:.3?}",
+                patches.len(),
+                patch_gen_time.elapsed()
+            );
+
+            log::info!("applying patches");
+            let patch_apply_time = Instant::now();
+            for patch in &patches {
+                unsafe {
+                    apply_patch(patch, &game.hook_buffer);
+                }
+            }
+
+            log::info!("patches applied in {:.3?}.", patch_apply_time.elapsed());
         }
+
         log::info!(
-            "all patches applied in {:.3?}. Arxan is now neutered",
-            patch_apply_time.elapsed()
+            "no stubs remain, arxan is disabled (took {:.3?} in {} passes).",
+            all_passes_time.elapsed(),
+            pass - 1
         );
 
         Ok(Status {

--- a/src/disabler/steamstub.rs
+++ b/src/disabler/steamstub.rs
@@ -176,7 +176,7 @@ impl<'a> SteamStubContext<'a> {
             *block ^= key;
             key = *block;
         }
-        for block in encrypted_strings.chunks_exact_mut(4) {
+        for block in encrypted_strings.as_chunks_mut::<4>().0 {
             let new_block = bytemuck::pod_read_unaligned::<u32>(block) ^ key;
             block.copy_from_slice(bytemuck::bytes_of(&new_block));
             key = new_block;
@@ -229,7 +229,7 @@ impl SteamStubHeader {
 
         let key = self.drmp_xtea_key;
         let mut xor_key = [0x5555_5555u32; 2];
-        for block in drmp_dll.chunks_exact_mut(8) {
+        for block in drmp_dll.as_chunks_mut::<8>().0 {
             const DELTA: u32 = 0x9E3779B9;
             let mut sum: u32 = DELTA.wrapping_mul(32);
 
@@ -268,7 +268,7 @@ impl SteamStubHeader {
     pub fn decrypt_strings(&self, pe: PeView<'_>, mut key: u32) -> pelite::Result<Vec<u8>> {
         let mut strings = self.strings(pe)?.to_owned();
 
-        for block in strings.chunks_exact_mut(4) {
+        for block in strings.as_chunks_mut::<4>().0 {
             let next_key: u32 = bytemuck::pod_read_unaligned(block);
             block.copy_from_slice(bytemuck::bytes_of(&(key ^ next_key)));
             key = next_key;


### PR DESCRIPTION
Elden Ring and Nightreign have encrypted Arxan stubs. Dearxan can't detect these currently, since it only does one analysis pass. This makes the disabler do passes in a loop until no new stubs show up.